### PR TITLE
use already existing dynamic inventory plugin

### DIFF
--- a/actions/deploy-infrastructure.yaml
+++ b/actions/deploy-infrastructure.yaml
@@ -13,7 +13,7 @@ parameters:
   cmd:
     description: "Command to run"
     immutable: true
-    default: "ansible-playbook --connection=local -i /opt/omnia/plugins/inventory deploy-infrastructure-repo.yml"
+    default: "ansible-playbook --connection=local -i /opt/omnia/infrastructure/plugins/inventory deploy-infrastructure-repo.yml"
 
   cwd:
     description: "Working directory where the command will be executed in eg. chdir"


### PR DESCRIPTION
`plugins/inventory` already exists in `/opt/omnia/infrastructure` (infrastructure repo), not sure keeping another copy in `/opt/omnia` is ideal.