### PR TITLE
Return ansible execution status code

### DIFF
--- a/actions/lib/ansible-playbook.sh
+++ b/actions/lib/ansible-playbook.sh
@@ -9,3 +9,5 @@ if [ -z $STACK ] ||  [ -z $LAYER ]; then
 else
   ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER | tr '{{' '-'
 fi
+
+exit ${PIPESTATUS[0]}

--- a/actions/lib/ansible-stack-layer-version-repo-environment.sh
+++ b/actions/lib/ansible-stack-layer-version-repo-environment.sh
@@ -12,3 +12,5 @@ if [ -z $PLAYBOOK ] ||  [ -z $STACK ] ||  [ -z $LAYER ] ||  [ -z $VERSION ] ||  
   exit 1
 fi
 ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER -e version=$VERSION -e app_repo=$APP_REPO -e env=$ENVIRONMENT | tr '{{' '-'
+
+exit ${PIPESTATUS[0]}

--- a/actions/lib/ansible-stack-layer-version-repo.sh
+++ b/actions/lib/ansible-stack-layer-version-repo.sh
@@ -11,3 +11,5 @@ if [ -z $PLAYBOOK ] ||  [ -z $STACK ] ||  [ -z $LAYER ] ||  [ -z $VERSION ] ||  
   exit 1
 fi
 ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER -e version=$VERSION -e app_repo=$APP_REPO | tr '{{' '-'
+
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Command piping is hiding ansible return code for returning from the wrapper scripts.

 Add an exit statement to return the appropriate command exit code for each script.